### PR TITLE
fix: avoid offline errors during nickname setup

### DIFF
--- a/Nang-cook/Nang-cook/AppDelegate.swift
+++ b/Nang-cook/Nang-cook/AppDelegate.swift
@@ -17,25 +17,28 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     // 1. Firebase 앱을 가장 먼저 초기화합니다.
     FirebaseApp.configure()
     
-    // 2. 디버그 모드일 때만 로컬 에뮬레이터에 연결합니다.
+    // 2. 디버그 모드에서는 환경 변수에 따라 로컬 에뮬레이터에 연결할 수 있습니다.
     #if DEBUG
-    print("🐛 디버그 모드: Firebase 로컬 에뮬레이터에 연결합니다.")
-    
-    // 로컬 네트워크의 Mac IP 주소 또는 localhost
-    // 시뮬레이터에서는 localhost(127.0.0.1)를 사용하고,
-    // 실제 기기 테스트 시에는 Mac의 IP 주소를 사용해야 합니다.
-    let host = "127.0.0.1" // 실제 기기 테스트 시 "192.168.1.223" 등으로 변경
-    
-    // Firestore 에뮬레이터 설정
-    let settings = Firestore.firestore().settings
-    settings.host = "\(host):8080"
-    settings.isSSLEnabled = false
-    settings.cacheSettings = MemoryCacheSettings()
-    Firestore.firestore().settings = settings
-    
-    // Auth 에뮬레이터 설정
-    Auth.auth().useEmulator(withHost: host, port: 9099)
-    
+    if ProcessInfo.processInfo.environment["USE_FIREBASE_EMULATOR"] == "1" {
+      print("🐛 디버그 모드: Firebase 로컬 에뮬레이터에 연결합니다.")
+
+      // 로컬 네트워크의 Mac IP 주소 또는 localhost
+      // 시뮬레이터에서는 localhost(127.0.0.1)를 사용하고,
+      // 실제 기기 테스트 시에는 Mac의 IP 주소를 사용해야 합니다.
+      let host = ProcessInfo.processInfo.environment["FIREBASE_EMULATOR_HOST"] ?? "127.0.0.1"
+
+      // Firestore 에뮬레이터 설정
+      let settings = Firestore.firestore().settings
+      settings.host = "\(host):8080"
+      settings.isSSLEnabled = false
+      settings.cacheSettings = MemoryCacheSettings()
+      Firestore.firestore().settings = settings
+
+      // Auth 에뮬레이터 설정
+      Auth.auth().useEmulator(withHost: host, port: 9099)
+    } else {
+      print("🐛 디버그 모드: Firebase 에뮬레이터를 사용하지 않습니다.")
+    }
     #else
     // --- 실제 앱 배포(릴리즈) 시에는 이 부분이 실행됩니다. ---
     // 별도의 코드가 없어도 FirebaseApp.configure()에 의해

--- a/Nang-cook/Nang-cook/MainView.swift
+++ b/Nang-cook/Nang-cook/MainView.swift
@@ -11,93 +11,69 @@ import FirebaseCore
 import FirebaseFirestore
 
 struct MainView: View {
-    
+
     @StateObject private var vm = NicknameViewModel()
-    // NavigationStack의 경로를 관리하는 상태 변수
-    @State private var path = [NavigationDestination]()
-    
+
     var body: some View {
-        // path를 바인딩하여 프로그래밍 방식의 화면 전환을 제어합니다.
-        NavigationStack(path: $path) {
-            VStack(spacing: 24) {
-                Spacer(minLength: 80)
-                
-                // ───── 안내 ─────
-                Text("환영합니다!")
-                    .font(.title).bold()
-                
-                Text("신규 회원이신가요?\n회원님의 닉네임을 정해주세요!")
-                    .multilineTextAlignment(.center)
-                    .font(.subheadline)
-                
-                // ───── 닉네임 입력 ─────
-                VStack(spacing: 12) {
-                    TextField("ex: 동동이", text: $vm.nickname)
-                        .textFieldStyle(.roundedBorder)
-                        .onChange(of: vm.nickname) { vm.validateNickname() }
-                    
-                    // 👇 --- 버튼 로직 단순화 --- 👇
-                    // isAvailable 상태에 따라 버튼을 다르게 보여줍니다.
-                    if vm.isAvailable {
-                        // 2. 닉네임 사용 가능 시 "닉네임 확정" 버튼
-                        Button("닉네임 확정") { vm.saveNickname() }
-                            .frame(width: 240, height: 44)
-                            .background(Color.blue)
-                            .foregroundColor(.white)
-                            .cornerRadius(8)
-                            .disabled(vm.isSaving) // 저장 중에는 비활성화
-                        
-                    } else {
-                        // 1. 초기 상태 "닉네임 중복 확인" 버튼
-                        Button("닉네임 중복 확인") { vm.checkAvailability() }
-                            .frame(width: 240, height: 44)
-                            .background(Color("FontColor2"))
-                            .foregroundColor(.white)
-                            .cornerRadius(8)
-                            .disabled(!vm.canCheck)
-                    }
-                    // --- 버튼 로직 단순화 끝 ---
-                    
-                    // 결과 메시지
-                    if let msg = vm.feedback {
-                        Text(msg)
-                            .font(.footnote)
-                            .foregroundColor(vm.feedbackColor)
-                    }
+        VStack(spacing: 24) {
+            Spacer(minLength: 80)
+
+            // ───── 안내 ─────
+            Text("환영합니다!")
+                .font(.title).bold()
+
+            Text("신규 회원이신가요?\n회원님의 닉네임을 정해주세요!")
+                .multilineTextAlignment(.center)
+                .font(.subheadline)
+
+            // ───── 닉네임 입력 ─────
+            VStack(spacing: 12) {
+                TextField("ex: 동동이", text: $vm.nickname)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: vm.nickname) { vm.validateNickname() }
+
+                // 👇 --- 버튼 로직 단순화 --- 👇
+                // isAvailable 상태에 따라 버튼을 다르게 보여줍니다.
+                if vm.isAvailable {
+                    // 2. 닉네임 사용 가능 시 "닉네임 확정" 버튼
+                    Button("닉네임 확정") { vm.saveNickname() }
+                        .frame(width: 240, height: 44)
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                        .disabled(vm.isSaving) // 저장 중에는 비활성화
+
+                } else {
+                    // 1. 초기 상태 "닉네임 중복 확인" 버튼
+                    Button("닉네임 중복 확인") { vm.checkAvailability() }
+                        .frame(width: 240, height: 44)
+                        .background(Color("FontColor2"))
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                        .disabled(!vm.canCheck)
                 }
-                .padding(.horizontal)
-                
-                Spacer()
-                
-            }
-            .padding()
-            .navigationTitle("냉쿡")
-            .navigationBarTitleDisplayMode(.inline)
-            // 👇 --- 화면 전환 로직 --- 👇
-            // 1. isSaved 상태가 true로 변하는 것을 감지합니다.
-            .onChange(of: vm.isSaved) { oldValue, newValue in
-                if newValue {
-                    // 2. path 배열에 목적지를 추가하여 화면 전환을 트리거합니다.
-                    path.append(.newView)
+                // --- 버튼 로직 단순화 끝 ---
+
+                // 결과 메시지
+                if let msg = vm.feedback {
+                    Text(msg)
+                        .font(.footnote)
+                        .foregroundColor(vm.feedbackColor)
                 }
             }
-            // 3. path에 추가된 목적지에 맞는 View를 실제로 보여줍니다.
-            .navigationDestination(for: NavigationDestination.self) { destination in
-                switch destination {
-                case .newView:
-                    NewView()
-                case .analyzing(let image):
-                    AnalyzingView(image: image, path: $path)
-                case .results(let image, let ingredients):
-                    ResultsView(image: image, ingredients: ingredients)
-                }
-            }
-            .alert("오류", isPresented: $vm.showError, actions: {
-                Button("확인", role: .cancel) { }
-            }, message: {
-                Text(vm.errorMessage ?? "알 수 없는 오류가 발생했습니다.")
-            })
+            .padding(.horizontal)
+
+            Spacer()
+
         }
+        .padding()
+        .navigationTitle("냉쿡")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("오류", isPresented: $vm.showError, actions: {
+            Button("확인", role: .cancel) { }
+        }, message: {
+            Text(vm.errorMessage ?? "알 수 없는 오류가 발생했습니다.")
+        })
     }
 }
     


### PR DESCRIPTION
## Summary
- add optional Firebase emulator configuration to prevent unwanted offline mode
- simplify nickname view to avoid navigation reset after saving nickname

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f904c75083268f251029169cfec7